### PR TITLE
Add "SVG to 2D mesh importing" to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,7 @@
 * Paintable textures				
 * Animated textures				
 * Directional 2D shadows				
+* SVG to 2D mesh importing				
 
 ### Animation	Features 
 * Transition graph				


### PR DESCRIPTION
I understand that the Godot Editor has support for SVG files for Editor icons but it would be great to also have support for SVGs in-game.

My day job company uses a different engine and our entire art pipeline for our current games are based around SVGs. Using SVGs reduces our build size and gives us resolution independent art which is great. If I'm ever going to be able to convince my company to switch to Godot, I'll need a path to be able use our existing SVG art in Godot.

EDIT: I have updated/changed this PR. Please see my latest comment for details.