### PR TITLE
Added youtube link as alternative to GDC vault (which needs flash).

### DIFF
--- a/GSoC/GSoC-2019.md
+++ b/GSoC/GSoC-2019.md
@@ -115,7 +115,8 @@ There are a number of errors this could catch that are not normally detected by 
 
 Implement this:
 
-https://www.gdcvault.com/play/1020583/Animation-Bootcamp-An-Indie-Approach
+https://www.youtube.com/watch?v=LNidsMesxSE
+Original Video: https://www.gdcvault.com/play/1020583/Animation-Bootcamp-An-Indie-Approach (Requires Flash)
 
 Should be doable as a generic/parametric character module.
 


### PR DESCRIPTION
The original link does not work on Firefox , Chrome, or Edge. I had to use Internet Explorer 11 to make the page work.