### PR TITLE
Tweak repository structure, remove references to wishlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This repository contains the [roadmap](ROADMAP.md) of all features that planned for implementation in [Godot](https://github.com/godotengine/godot).
 
-In the [roadmap file](ROADMAP.md), all the goals are listed. These are features that are planned and approved for implementation by the core developers and contributors. If a feature requires broader description, an extra document can be  put inside the features folder (in a sub-folder if it intends to include images), and linked from the main file.
+In the [roadmap file](ROADMAP.md), all the goals are listed. These are features that are planned and approved for implementation by the core developers and contributors.
 
-In the [wishlist file](WISHLIST.md), features that would be nice to have are listed. These are features that are not planned for the near or medium term, or that are simply did not get enough interest from the core contributors. The wishlist folder is available to add relevant documents to explain features in detail.
+Feature proposals should be discussed in the [Godot proposals](https://github.com/godotengine/godot-proposals) repository, not in this repository's issue tracker.
 
 ## FAQ
 

--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -1,3 +1,0 @@
-# Wishlist
-
-Here be dragons.

--- a/done/README.md
+++ b/done/README.md
@@ -1,1 +1,0 @@
-If a feature is done, move it here.

--- a/features/README.md
+++ b/features/README.md
@@ -1,3 +1,0 @@
-# Features
-
-If a feature needs more detail, add a file (or folder, if it contains images or more than one page) for describing the feature, then link it fromt he main roadmap or wishlist page.

--- a/wishlist/README.md
+++ b/wishlist/README.md
@@ -1,1 +1,0 @@
-If a wishlist item needs more detail, create a page here (.md), or in a sub-folder if it contains images or more pages.


### PR DESCRIPTION
The wishlist was never completed and was superseded by the [Godot proposals](https://github.com/godotengine/godot-proposals) repository.

This also removes the `features/` and `done/` folders as they were empty.